### PR TITLE
Add human readable results link

### DIFF
--- a/templates/year/batch/batchB.tex.fykos
+++ b/templates/year/batch/batchB.tex.fykos
@@ -47,7 +47,7 @@
 	\qrcode[height=2.5cm]{https://fykos.cz/rocnik\theyear/poradi/serie\thesolvedbatch}
 	\bigskip
 
-	\parbox{0.3\textwidth}{\centering Kompletní výsledky najdete na \url{https://fykos.cz}.}
+	\parbox{0.3\textwidth}{\centering Kompletní výsledky najdete na \url{https://fykos.cz/rocnik\theyear/poradi/serie\thesolvedbatch}.}
 \end{center}
 
 \vfill


### PR DESCRIPTION
URL must exist because of QR, so add it in direct form for easier input on devices without QR capability.

(Not tested.)